### PR TITLE
Update pyproject.toml

### DIFF
--- a/modules/streaming_pipeline/pyproject.toml
+++ b/modules/streaming_pipeline/pyproject.toml
@@ -17,7 +17,7 @@ sentencepiece = "^0.1.99"
 qdrant-client = "1.1.1"
 fire = "^0.5.0"
 transformers = "^4.33.1"
-torch = {version = "2.0.1+cpu", source = "torch-cpu"}
+torch = { platform = "linux", version = "2.0.1+cpu", source = "torch-cpu" }
 pyyaml = "6.0.1"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Ran into a `Unable to find installation candidates for torch (2.1.2+cpu)` error on Macbook (Intel) when not specifying `platform` key (i.e. `torch = { platform = "linux", version = "2.0.1+cpu", source = "torch-cpu" }`)